### PR TITLE
Ajustando endpoints de gerenciamento de emprestimos do cliente

### DIFF
--- a/src/main/java/br/edu/ufape/agiota/controllers/EmprestimoClienteController.java
+++ b/src/main/java/br/edu/ufape/agiota/controllers/EmprestimoClienteController.java
@@ -13,43 +13,43 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/cliente/emprestimos")
+@RequestMapping("/cliente/{id}")
 public class EmprestimoClienteController {
 
     @Autowired
     private Fachada fachada;
 
-    @GetMapping
-    public ResponseEntity<?> listarEmprestimosCliente(@RequestParam("clienteId") long clienteId) {
+    @GetMapping("/emprestimos")
+    public ResponseEntity<?> listarEmprestimosCliente(@PathVariable("id") long clienteId) {
         List<Emprestimo> result = fachada.listarEmprestimosCliente(clienteId);
         return ResponseEntity.ok().body(result);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> buscarEmprestimo(@PathVariable long id) {
+    @GetMapping("/emprestimos/{emprestimoId}")
+    public ResponseEntity<?> buscarEmprestimo(@PathVariable("id") long clienteId, @PathVariable long emprestimoId) {
         try {
-            Emprestimo emprestimo = fachada.buscarEmprestimo(id);
+            Emprestimo emprestimo = fachada.buscarEmprestimo(clienteId, emprestimoId);
             return ResponseEntity.ok().body(emprestimo);
         } catch (RegistroNaoEncontradoException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
 
-    @PostMapping
-    public ResponseEntity<?> criarSolicitacaoEmprestimo(@RequestBody @Valid EmprestimoClienteDTO emprestimoClienteDTO) {
+    @PostMapping("/emprestimos")
+    public ResponseEntity<?> criarSolicitacaoEmprestimo(@RequestBody @Valid EmprestimoClienteDTO emprestimoClienteDTO, @PathVariable("id") long clienteId) {
         try {
-            Emprestimo emprestimo = fachada.criarSolicitacaoEmprestimo(emprestimoClienteDTO);
+            Emprestimo emprestimo = fachada.criarSolicitacaoEmprestimo(emprestimoClienteDTO, clienteId);
             return ResponseEntity.ok().body(emprestimo);
         } catch (RegistroNaoEncontradoException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
 
-    @PatchMapping("/{id}")
-    public ResponseEntity<?> cancelarSolicitacaoEmprestimo(@PathVariable long id)
+    @PatchMapping("/emprestimos/{emprestimoId}")
+    public ResponseEntity<?> cancelarSolicitacaoEmprestimo(@PathVariable long emprestimoId, @PathVariable("id") long clienteId)
     {
         try {
-            return ResponseEntity.ok().body(fachada.cancelarSolicitacaoEmprestimo(id));
+            return ResponseEntity.ok().body(fachada.cancelarSolicitacaoEmprestimo(emprestimoId, clienteId));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }

--- a/src/main/java/br/edu/ufape/agiota/dtos/EmprestimoClienteDTO.java
+++ b/src/main/java/br/edu/ufape/agiota/dtos/EmprestimoClienteDTO.java
@@ -21,10 +21,6 @@ public class EmprestimoClienteDTO {
 
     @NotNull
     @Positive
-    private long clienteId;
-
-    @NotNull
-    @Positive
     private long agiotaId;
 
     public void toSolicitarEmprestimo(Emprestimo emprestimo, Cliente cliente, Agiota agiota) {

--- a/src/main/java/br/edu/ufape/agiota/fachada/Fachada.java
+++ b/src/main/java/br/edu/ufape/agiota/fachada/Fachada.java
@@ -74,17 +74,17 @@ public class Fachada {
         return emprestimoService.listarEmprestimosCliente(clienteId);
     }
 
-    public Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO)
+    public Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO, long clienteId)
     {
-        return emprestimoService.criarSolicitacaoEmprestimo(emprestimoClienteDTO);
+        return emprestimoService.criarSolicitacaoEmprestimo(emprestimoClienteDTO, clienteId);
     }
 
-    public boolean cancelarSolicitacaoEmprestimo(long idEmprestimo) {
-        return emprestimoService.cancelarSolicitacaoEmprestimo(idEmprestimo);
+    public boolean cancelarSolicitacaoEmprestimo(long idEmprestimo, long clienteId) {
+        return emprestimoService.cancelarSolicitacaoEmprestimo(idEmprestimo, clienteId);
     }
 
-    public Emprestimo buscarEmprestimo(long idEmprestimo) {
-        return emprestimoService.buscarEmprestimo(idEmprestimo);
+    public Emprestimo buscarEmprestimo(long clienteId, long idEmprestimo) {
+        return emprestimoService.buscarEmprestimoCliente(clienteId, idEmprestimo);
     }
 
     public List<Emprestimo> listarEmprestimosAgiota(long agiotaId) {

--- a/src/main/java/br/edu/ufape/agiota/negocio/repositorios/EmprestimoRepository.java
+++ b/src/main/java/br/edu/ufape/agiota/negocio/repositorios/EmprestimoRepository.java
@@ -12,4 +12,6 @@ public interface EmprestimoRepository extends JpaRepository<Emprestimo, Long> {
 
     Emprestimo findByIdAndAgiotaId(Long id, Long agiotaId);
 
+    Emprestimo findByIdAndClienteId(Long id, Long clienteId);
+
 }

--- a/src/main/java/br/edu/ufape/agiota/negocio/services/EmprestimoService.java
+++ b/src/main/java/br/edu/ufape/agiota/negocio/services/EmprestimoService.java
@@ -35,8 +35,8 @@ public class EmprestimoService implements EmprestimoServiceInterface {
     }
 
     @Override
-    public Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO) {
-        Cliente cliente = clienteService.buscarCliente(emprestimoClienteDTO.getClienteId());
+    public Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO, long clienteId) {
+        Cliente cliente = clienteService.buscarCliente(clienteId);
         Agiota agiota = agiotaService.buscarAgiota(emprestimoClienteDTO.getAgiotaId());
 
         Emprestimo emprestimo = new Emprestimo();
@@ -47,8 +47,8 @@ public class EmprestimoService implements EmprestimoServiceInterface {
     }
 
     @Override
-    public boolean cancelarSolicitacaoEmprestimo(long idEmprestimo) {
-        Emprestimo emprestimo = buscarEmprestimo(idEmprestimo);
+    public boolean cancelarSolicitacaoEmprestimo(long idEmprestimo, long clienteId) {
+        Emprestimo emprestimo = buscarEmprestimoCliente(clienteId, idEmprestimo);
 
         emprestimo.checarPossibilidadeDeCancelar();
 
@@ -59,7 +59,6 @@ public class EmprestimoService implements EmprestimoServiceInterface {
         return true;
     }
 
-    @Override
     public Emprestimo buscarEmprestimo(long id) {
         Optional<Emprestimo> emprestimoOpt = emprestimoRepository.findById(id);
 
@@ -78,6 +77,17 @@ public class EmprestimoService implements EmprestimoServiceInterface {
     @Override
     public Emprestimo buscarEmprestimoAgiota(long agiotaId, long emprestimoId) {
         Emprestimo emprestimo = emprestimoRepository.findByIdAndAgiotaId(emprestimoId, agiotaId);
+
+        if (isNull(emprestimo)) {
+            throw new RegistroNaoEncontradoException("Empréstimo não encontrado");
+        }
+
+        return emprestimo;
+    }
+
+    @Override
+    public Emprestimo buscarEmprestimoCliente(long clienteId, long emprestimoId) {
+        Emprestimo emprestimo = emprestimoRepository.findByIdAndClienteId(emprestimoId, clienteId);
 
         if (isNull(emprestimo)) {
             throw new RegistroNaoEncontradoException("Empréstimo não encontrado");

--- a/src/main/java/br/edu/ufape/agiota/negocio/services/interfaces/EmprestimoServiceInterface.java
+++ b/src/main/java/br/edu/ufape/agiota/negocio/services/interfaces/EmprestimoServiceInterface.java
@@ -9,11 +9,11 @@ import java.util.List;
 public interface EmprestimoServiceInterface {
     List<Emprestimo> listarEmprestimosCliente(long clienteId);
 
-    Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO);
+    Emprestimo criarSolicitacaoEmprestimo(EmprestimoClienteDTO emprestimoClienteDTO, long clienteId);
 
-    boolean cancelarSolicitacaoEmprestimo(long idEmprestimo);
+    boolean cancelarSolicitacaoEmprestimo(long idEmprestimo, long clienteId);
 
-    Emprestimo buscarEmprestimo(long id);
+    Emprestimo buscarEmprestimoCliente(long clienteId, long idEmprestimo);
 
     List<Emprestimo> listarEmprestimosAgiota(long agiotaId);
 


### PR DESCRIPTION
Os endpoints referentes ao gerenciamento de emprestimos pelo cliente foram modificados para pegar todos os ids via url e não mais nos params da requisição